### PR TITLE
[fe-test-files-check-action] Fix wrong it.each detection string

### DIFF
--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -52,9 +52,9 @@ async function checkHasTestInRelatedTestFile(sourceFileFullname, allowTodo) {
    */
   const hasTest = [
     'it(',
-    'it.each(',
+    'it.each',
     'test(',
-    'test.each(',
+    'test.each',
   ].some(value => testFileContent.includes(value));
 
   if (!allowTodo) {


### PR DESCRIPTION
修正檢查是否有測試時未考慮 it.each 有 template literal 的字串，改為只要有 `it.each` 字樣就給過。
ref: [it.each api](https://jestjs.io/docs/api#testeachtablename-fn-timeout)