### PR TITLE
[fe-test-file-check-action] skip index.js on checking test file

### DIFF
--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -75,7 +75,10 @@ async function hasTestForSourceFile(sourceFilename, allowTodo) {
   core.debug(`checking if ${sourceFilename} has related test file...`);
   if (
     (['.js', '.ts'].every(ext => !sourceFilename.includes(ext)))
-    || sourceFilename.includes('.test.js')
+    || [
+      '.test.js',
+      'index.js',
+    ].some(value => sourceFilename.includes(value))
   ) {
     return true;
   }


### PR DESCRIPTION
考慮到大多數情況下 `index.js` 僅用於 export module 給外部 user，在 `fe-test-file-check-action` 中就不檢查 `index.js` 是否有對應測試檔了。