### PR TITLE
[fe-test-files-checks-action] temp fix for skipping hook call assertion

### DIFF
--- a/fe-test-files-check-action/dist/index.js
+++ b/fe-test-files-check-action/dist/index.js
@@ -9935,6 +9935,8 @@ async function checkHasTestInRelatedTestFile(sourceFileFullname, allowTodo) {
     'it.each',
     'test(',
     'test.each',
+    // Temporary fix for skipping hook call assertion utils in fe-test-utils.
+    'expectToBe',
   ].some(value => testFileContent.includes(value));
 
   if (!allowTodo) {

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -55,6 +55,8 @@ async function checkHasTestInRelatedTestFile(sourceFileFullname, allowTodo) {
     'it.each',
     'test(',
     'test.each',
+    // Temporary fix for skipping hook call assertion utils in fe-test-utils.
+    'expectToBe',
   ].some(value => testFileContent.includes(value));
 
   if (!allowTodo) {


### PR DESCRIPTION
- asana: https://app.asana.com/0/347798529122928/1204019598464825/f

目前 test files 檢查會因為內部的測試套件包裏了 `it()` 而 failed，這裡先暫時加上關鍵字讓檢查會過
未來可以考慮用 jest reporter api 抓出正確的 test case 數