### PR TITLE
[fe-test-files-check-action] Ignore `tape.js` and `fixture`

### DIFF
--- a/fe-test-files-check-action/dist/index.js
+++ b/fe-test-files-check-action/dist/index.js
@@ -9883,6 +9883,13 @@ const minimatch = __nccwpck_require__(2002);
 const path = __nccwpck_require__(1017);
 const core = __nccwpck_require__(2186);
 
+const NON_TEST_JS_FILE_NAME_SEGMENTS = [
+  '.test.js',
+  'index.js',
+  '.tape.js',
+  'fixture',
+];
+
 function getFilenamesInTestScope(fileGlob, filenames) {
   return filenames.filter(filename => minimatch(filename, fileGlob));
 }
@@ -9957,10 +9964,7 @@ async function hasTestForSourceFile(sourceFilename, allowTodo) {
   core.debug(`checking if ${sourceFilename} has related test file...`);
   if (
     (['.js', '.ts'].every(ext => !sourceFilename.includes(ext)))
-    || [
-      '.test.js',
-      'index.js',
-    ].some(value => sourceFilename.includes(value))
+    || NON_TEST_JS_FILE_NAME_SEGMENTS.some(value => sourceFilename.includes(value))
   ) {
     return true;
   }
@@ -11247,7 +11251,7 @@ async function listChangedFiles() {
      * Deleted files don't count.
      */
     const filePaths = filesResponseData.nodes
-      .filter(({ changeType }) => ![PATCH_STATUS.DELETED].includes(changeType) )
+      .filter(({ changeType }) => ![PATCH_STATUS.DELETED].includes(changeType))
       .map(({ path }) => path);
     result = result.concat(filePaths);
     const { pageInfo } = filesResponseData;

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -3,6 +3,12 @@ const minimatch = require('minimatch');
 const path = require('path');
 const core = require('@actions/core');
 
+const NON_TEST_JS_FILES_POSTFIX = [
+  '.test.js',
+  'index.js',
+  '.tape.js',
+];
+
 function getFilenamesInTestScope(fileGlob, filenames) {
   return filenames.filter(filename => minimatch(filename, fileGlob));
 }
@@ -77,10 +83,7 @@ async function hasTestForSourceFile(sourceFilename, allowTodo) {
   core.debug(`checking if ${sourceFilename} has related test file...`);
   if (
     (['.js', '.ts'].every(ext => !sourceFilename.includes(ext)))
-    || [
-      '.test.js',
-      'index.js',
-    ].some(value => sourceFilename.includes(value))
+    || NON_TEST_JS_FILES_POSTFIX.some(value => sourceFilename.includes(value))
   ) {
     return true;
   }

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -3,10 +3,11 @@ const minimatch = require('minimatch');
 const path = require('path');
 const core = require('@actions/core');
 
-const NON_TEST_JS_FILES_POSTFIX = [
+const NON_TEST_JS_FILE_NAME_SEGMENTS = [
   '.test.js',
   'index.js',
   '.tape.js',
+  'fixture',
 ];
 
 function getFilenamesInTestScope(fileGlob, filenames) {
@@ -83,7 +84,7 @@ async function hasTestForSourceFile(sourceFilename, allowTodo) {
   core.debug(`checking if ${sourceFilename} has related test file...`);
   if (
     (['.js', '.ts'].every(ext => !sourceFilename.includes(ext)))
-    || NON_TEST_JS_FILES_POSTFIX.some(value => sourceFilename.includes(value))
+    || NON_TEST_JS_FILE_NAME_SEGMENTS.some(value => sourceFilename.includes(value))
   ) {
     return true;
   }


### PR DESCRIPTION
## asana task
- https://app.asana.com/0/347798529122928/1204133745008950/f
- https://ichef.slack.com/archives/CEZGQ2FK4/p1684472817123989

- 當 changed filename(包含其檔案路徑) 含有 `tape.js` / `fixture` 的名稱片段就略過
- 做一些小重構抽取「檔案不需檢查測試」「有 test case」的關鍵字