### PR TITLE
[fe-test-files-check-action] 對 constant 檔案不檢查測試是否存在

### DIFF
--- a/fe-test-files-check-action/dist/index.js
+++ b/fe-test-files-check-action/dist/index.js
@@ -9883,11 +9883,26 @@ const minimatch = __nccwpck_require__(2002);
 const path = __nccwpck_require__(1017);
 const core = __nccwpck_require__(2186);
 
-const NON_TEST_JS_FILE_NAME_SEGMENTS = [
+const FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS = [
   '.test.js',
   'index.js',
   '.tape.js',
   'fixture',
+  'constant',
+];
+
+const TEST_CASE_KEYWORDS = [
+  'it(',
+  'it.each',
+  'test(',
+  'test.each',
+  // Temporary fix for skipping hook call assertion utils in fe-test-utils.
+  'expectToBe',
+]
+
+const TODO_TEST_CASE_KEYWORDS = [
+  'it.todo(',
+  'test.todo(',
 ];
 
 function getFilenamesInTestScope(fileGlob, filenames) {
@@ -9937,20 +9952,13 @@ async function checkHasTestInRelatedTestFile(sourceFileFullname, allowTodo) {
   /**
    * TODO: reimplement this by checking AST
    */
-  const hasTest = [
-    'it(',
-    'it.each',
-    'test(',
-    'test.each',
-    // Temporary fix for skipping hook call assertion utils in fe-test-utils.
-    'expectToBe',
-  ].some(value => testFileContent.includes(value));
+  const hasTest = TEST_CASE_KEYWORDS.some(value => testFileContent.includes(value));
 
   if (!allowTodo) {
     return hasTest;
   }
 
-  const hasTodo = ['it.todo(', 'test.todo('].some(value => testFileContent.includes(value))
+  const hasTodo = TODO_TEST_CASE_KEYWORDS.some(value => testFileContent.includes(value))
 
   return hasTest || hasTodo;
 }
@@ -9964,7 +9972,7 @@ async function hasTestForSourceFile(sourceFilename, allowTodo) {
   core.debug(`checking if ${sourceFilename} has related test file...`);
   if (
     (['.js', '.ts'].every(ext => !sourceFilename.includes(ext)))
-    || NON_TEST_JS_FILE_NAME_SEGMENTS.some(value => sourceFilename.includes(value))
+    || FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS.some(value => sourceFilename.includes(value))
   ) {
     return true;
   }

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -8,6 +8,7 @@ const FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS = [
   'index.js',
   '.tape.js',
   'fixture',
+  'constant',
 ];
 
 const TEST_CASE_KEYWORDS = [


### PR DESCRIPTION
`/shared` 下面可能會動到 constants，但是那些檔案通常不需要自己的測試檔案
通常會在其他測試中被 cover 到