### PR TITLE
[check-untested-files] ignore type definition file in test files check action

### DIFF
--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -7,6 +7,7 @@ const FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS = [
   '.test.js',
   'index.js',
   '.tape.js',
+  '.d.ts',
   'fixture',
   'constant',
 ];


### PR DESCRIPTION
略過對 `.d.ts` 檔的測試檢查。當專案改到 `.d.ts` 時就不會導致 action failed。