### PR TITLE
Run all JS actions with node20

### DIFF
--- a/check-asana-task-created/action.yml
+++ b/check-asana-task-created/action.yml
@@ -11,5 +11,5 @@ outputs:
     description: Task created or not
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/fe-test-files-check-action/action.yml
+++ b/fe-test-files-check-action/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'When allowTodo=true, regard the source file as tested if there is `it.todo()` in test file.'
     default: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/get-github-app-token/action.yml
+++ b/get-github-app-token/action.yml
@@ -19,5 +19,5 @@ outputs:
     description: Access token, authenticated as specified Github App.
 
 runs:
-  using: node16
+  using: node20
   main: dist/index.js

--- a/get-package-version/action.yml
+++ b/get-package-version/action.yml
@@ -4,5 +4,5 @@ outputs:
   version:
     description: Value of "version" field
 runs:
-  using: node16
+  using: node20
   main: index.js


### PR DESCRIPTION
- 因為 Node 16 一年前 (2023-09-11) 就 [End of Life](https://nodejs.org/en/blog/announcements/nodejs16-eol/) 了 
- Github 也宣布 [今年內要淘汰 Node 16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)、全面轉移到 Node 20

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207702326954631