### PR TITLE
Support TS test file

### DIFF
--- a/fe-test-files-check-action/dist/index.js
+++ b/fe-test-files-check-action/dist/index.js
@@ -9892,6 +9892,7 @@ const FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS = [
   'index',
   'constant',
   '/types/',
+  'test.ts',
 ];
 
 const TEST_CASE_KEYWORDS = [

--- a/fe-test-files-check-action/dist/index.js
+++ b/fe-test-files-check-action/dist/index.js
@@ -9925,6 +9925,8 @@ async function getTestFileContent(sourceFileFullname) {
   const possibleTestFilename = [
     `${sourceFilenameWithoutExt}.test.js`,
     `${sourceFilenameWithoutExt}.test.jsx`,
+    `${sourceFilenameWithoutExt}.test.ts`,
+    `${sourceFilenameWithoutExt}.test.tsx`,
   ];
   const possibleTestFileFullNames = possibleTestFilename.map(
     testFileName => `${testFileDir}/${testFileName}`

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -12,6 +12,7 @@ const FILE_NAME_KEYWORDS_NOT_REQUIRING_TESTS = [
   'index',
   'constant',
   '/types/',
+  'test.ts',
 ];
 
 const TEST_CASE_KEYWORDS = [

--- a/fe-test-files-check-action/src/findUntestedFiles.js
+++ b/fe-test-files-check-action/src/findUntestedFiles.js
@@ -45,6 +45,8 @@ async function getTestFileContent(sourceFileFullname) {
   const possibleTestFilename = [
     `${sourceFilenameWithoutExt}.test.js`,
     `${sourceFilenameWithoutExt}.test.jsx`,
+    `${sourceFilenameWithoutExt}.test.ts`,
+    `${sourceFilenameWithoutExt}.test.tsx`,
   ];
   const possibleTestFileFullNames = possibleTestFilename.map(
     testFileName => `${testFileDir}/${testFileName}`


### PR DESCRIPTION
- 在雲餐專案中，[嘗試用 TS 寫測試](https://github.com/iCHEF/iCHEF-online-restaurant/pull/3053/files#diff-f05cb217c2dd351b09d0283f4df99539a54dd7e7252bd0fe5103af1944043527R1)，untest file action fail
  1. 原因是還沒把 test.ts 排除測試範圍
  2. 擴增 .test.ts, .test.tsx 到 possibleTestFiles